### PR TITLE
fixed error when no parameters passed

### DIFF
--- a/client_side_validations.gemspec
+++ b/client_side_validations.gemspec
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
 
     if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
       s.add_runtime_dependency(%q<validation_reflection-active_model>, ["= 0.3.1"])
-      s.add_runtime_dependency(%q<json>, ["= 1.4.3"])
+      s.add_runtime_dependency(%q<json>, [">= 1.4.3"])
       s.add_development_dependency(%q<jspec>, [">= 0"])
       s.add_development_dependency(%q<rspec>, [">= 0"])
       s.add_development_dependency(%q<actionpack>, ["= 3.0.0"])

--- a/lib/client_side_validations.rb
+++ b/lib/client_side_validations.rb
@@ -23,6 +23,8 @@ module ClientSideValidations
       when %r{^/validations/uniqueness.json}
         params              = {}.merge!(CGI::parse(env['QUERY_STRING']))
         field               = params.keys.first
+        # request has been sent with no query parameters and is invalid
+        return [400, {'Content-Type' => 'application/json'}, []] unless field
         resource, attribute = field.split(/[^\w]/)
         value               = params[field][0]
         # Because params returns an array for each field value we want to always grab


### PR DESCRIPTION
Hi,

I know this gem is not maintained any more, unfortunately we have an app stuck on rails 2.3 for the time being so have to use this older one. Once we deployed the app we noticed errors being produced, when /validations/uniqueness.json is called with no parameters an exception is raised, which happend quite a lot from the google bot and other search bots. I added a quick fix to return a 400 if this is called with no parameters. Would it be possible to merge this in and release a new version of the gem?

Thanks
Jamie
